### PR TITLE
docs: クラウド開発環境(web-new)セットアップ手順を AGENTS.md に追記

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,3 +96,29 @@ clone も不要(lll-legacy の `~/atomcam_tools` が正本)。
 - [docs/development/hil-bootstrap.md](docs/development/hil-bootstrap.md)
 - [docs/development/repo-map.md](docs/development/repo-map.md)
 - 作業経緯/未解決: [docs/development/refactor-notes.md](docs/development/refactor-notes.md)
+
+## Cursor Cloud specific instructions
+
+クラウド VM(ハードウェア無し)で実際に開発・実行できるのは **`web-new/`(React 19 + Vite + TypeScript の WebUI)** のみ。
+ファーム本体ビルド(`make build` = Docker + Buildroot で MIPS クロスコンパイル)と
+デプロイ/HIL(`make deploy` / `scripts/hil/*` / `deploy_remote.sh`)は **重いビルドや実機カメラが前提**で
+クラウド VM では完結しない(コマンドの正本は本ファイル上部と `docs/development/`)。
+
+### web-new(主開発対象)
+
+- パッケージマネージャは **npm**(`web-new/package-lock.json`)。CI は **Node 22**(`.github/workflows/webui.yml`)。
+- コマンドは `web-new/package.json` の scripts が正本。要点:
+  - `npm run dev` — Vite dev server(**port 5173**)。`npm run test` — vitest。
+  - `npm run lint` / `npm run typecheck` / `npm run build`(+ `npm run budget` = gzip バンドル上限チェック)。
+  - `npm run e2e` は Playwright ブラウザが別途必要(`npx playwright install chromium`。update script には含めない)。
+- **バックエンドは MSW が自動モック**する(`import.meta.env.DEV` または demo ビルド時)。
+  実機の CGI(`overlay_rootfs/var/www/cgi-bin`)は起動せず、`.env` やバックエンド常駐も不要で dev/test/build が完結する。
+
+### 非自明な落とし穴(要記憶)
+
+- **MSW の Service Worker は初回ロードで登録された後にページを制御し始める**。
+  データ取得を伴うルートへ**直接 URL でハードリロード**すると、SW が制御を握る前の fetch が失敗し
+  白画面 + `Failed to fetch`(`mockServiceWorker`)になることがある。**サイドバー内の SPA 遷移**を使うか、一度リロードする。
+- **ナビ項目は端末モデルで出し分け**(`web-new/src/components/layout/AppLayout.tsx` の `filterNav`)。
+  既定モックは Swing モデルのため **`/settings/camera`(ATOM 専用)はサイドバーに出ず、直接開くと空表示**になる(仕様。バグではない)。
+  Swing では代わりに `/settings/cruise` が出る。動作確認は `/settings/system` 等の共通ページが確実。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Cursor Cloud VM 上で本リポジトリの開発環境をセットアップし、実行できることを検証した。VM(ハードウェア無し)で完結して動かせるのは `web-new/`(React 19 + Vite + TypeScript の WebUI)。バックエンドは MSW が自動モックするため実機カメラや `.env` 無しで dev/test/build が回る。

ファーム本体ビルド(`make build` = Docker + Buildroot の MIPS クロスコンパイル)とデプロイ/HIL(`make deploy` / `scripts/hil/*`)は重いビルドや実機前提のため VM では対象外。

## 変更点

- `AGENTS.md` に `## Cursor Cloud specific instructions` を追記
  - VM で動かせる対象(web-new)と対象外(ファームビルド / HIL)の切り分け
  - web-new の dev/test/lint/typecheck/build/budget コマンドと Node 22 / npm 前提
  - 非自明な落とし穴2点: (1) MSW の Service Worker はハードリロード直後に fetch が失敗し得る → SPA 内遷移を使う (2) ナビは端末モデルで出し分け、既定モック(Swing)では `/settings/camera` は空表示(仕様)

## 検証(web-new)

| 項目 | コマンド | 結果 |
|------|----------|------|
| Lint | `npm run lint` | pass(0 errors, 既存 warning 1) |
| Typecheck | `npm run typecheck` | pass |
| Unit tests | `npm run test` | 76 passed / 10 files |
| Build | `npm run build` | pass |
| Bundle budget | `npm run budget` | pass(initial 162.4KB / total 299.8KB) |
| Run | `npm run dev` | port 5173 で起動、UI 操作を確認 |

hello-world: System 設定でトグルを変更 → 「未保存の変更」バー表示 → Save → 「Saved」トースト表示 → モックバックエンドへ永続化されることを確認。

## 更新スクリプト

`npm --prefix web-new ci`(冪等・最小)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6887c19c-034e-484d-a90a-63e9fd0f5ccd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6887c19c-034e-484d-a90a-63e9fd0f5ccd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

